### PR TITLE
Drop redundant libm linking flag

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -3,7 +3,7 @@ bin_PROGRAMS = pixz
 pixz_CC = $(PTHREAD_CC)
 pixz_CFLAGS = $(PTHREAD_CFLAGS) -Wall -Wno-unknown-pragmas
 pixz_CPPFLAGS = $(LIBARCHIVE_CPPFLAGS) $(LZMA_CPPFLAGS)
-pixz_LDADD = -lm $(LIBARCHIVE_LIBS) $(LZMA_LIBS) $(PTHREAD_LIBS)
+pixz_LDADD = $(LIBARCHIVE_LIBS) $(LZMA_LIBS) $(PTHREAD_LIBS)
 
 pixz_SOURCES = \
 	common.c \


### PR DESCRIPTION
If AC_CHEK_LIB([m], [...]) has already been invoked, then no need to do this again.

Note, I'm not sure why -lm was added here, rationality?