### PR TITLE
include man page in release tarball

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,10 +12,20 @@ AM_INIT_AUTOMAKE([foreign])
 
 # Checks for programs.
 AC_PROG_CC_STDC
-AC_CHECK_PROG(A2X, a2x, a2x, [])
-if test "x$A2X" = x ; then
-  AC_MSG_ERROR([AsciiDoc not found.])
-fi
+
+# Check for a2x only if the man page is missing, i.e. we are building from git. The release tarballs
+# are set up to include the man pages. This way, only people creating tarballs via `make dist` and
+# people building from git need a2x as a dependency.
+AC_CHECK_FILE(
+  [src/pixz.1],
+  [],
+  [
+    AC_CHECK_PROG(A2X, a2x, a2x, [])
+    if test "x$A2X" = x ; then
+      AC_MSG_ERROR([AsciiDoc not found, not able to generate the man page.])
+    fi
+  ]
+)
 
 # Checks for libraries.
 AC_CHECK_LIB([m], [ceil])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -15,6 +15,8 @@ pixz_SOURCES = \
 	read.c \
 	write.c
 
+# TODO remove when possible: This is a hack because a2x is not able to output the man pages to a
+# specific directory, only to where the source is.
 pixz.1: pixz.1.asciidoc
 	$(A2X) -a manversion=$(PACKAGE_VERSION) -f manpage $(top_srcdir)/src/pixz.1.asciidoc
 	if ! test -f pixz.1 ; then mv -f $(top_srcdir)/src/pixz.1 . ; fi
@@ -23,4 +25,4 @@ man_MANS = pixz.1
 
 CLEANFILES = pixz.1
 
-EXTRA_DIST = pixz.1.asciidoc
+EXTRA_DIST = $(man_MANS) pixz.1.asciidoc


### PR DESCRIPTION
- adds man page to `EXTRA_DIST`
- `configure` checks for `a2x` only if the man page does not exist (poor mans way of checking if we build from git or release tarball)
- fixes #50