### PR TITLE
Don't ignore output option without input option

### DIFF
--- a/src/pixz.c
+++ b/src/pixz.c
@@ -121,7 +121,7 @@ int main(int argc, char **argv) {
             if (opath)
                 usage("Multiple output files specified");
             opath = argv[1];
-        } else if (op != OP_LIST) {
+        } else if (op != OP_LIST && !opath) {
             iremove = true;
             opath = auto_output(op, argv[0]);
 			if (!opath)


### PR DESCRIPTION
Currently, if the `-o` option is given without the `-i` option, it is silently ignored.  I think this behavior is unintuitive and I can't find it mentioned anywhere in the documentation.

This PR changes the behavior to respect `-o` even without `-i`, which I find to be much more reasonable.

Thanks for considering,
Kevin