### PR TITLE
Fixed typo in block_alloc

### DIFF
--- a/src/write.c
+++ b/src/write.c
@@ -260,7 +260,7 @@ static void *block_create() {
 static void block_alloc(io_block_t *ib, block_parts parts) {
     if ((parts & BLOCK_IN) && !ib->input)
         ib->input = malloc(gBlockInSize);
-    if ((parts & BLOCK_IN) && !ib->output)
+    if ((parts & BLOCK_OUT) && !ib->output)
         ib->output = malloc(gBlockOutSize);
     if (!ib->input || !ib->output)
         die("Can't allocate blocks");


### PR DESCRIPTION
In `write.c` Line 263, `parts` is compared against `BLOCK_IN` despite dealing with output, and the corresponding `block_dealloc` checks `BLOCK_OUT` instead. Is this a typo?

```c
static void block_alloc(io_block_t *ib, block_parts parts) {
    if ((parts & BLOCK_IN) && !ib->input)
        ib->input = malloc(gBlockInSize);
    if ((parts & BLOCK_IN) && !ib->output) // <-- I believe this line should be BLOCK_OUT
        ib->output = malloc(gBlockOutSize);
    if (!ib->input || !ib->output)
        die("Can't allocate blocks");
}
```

The corresponding `block_dealloc`:
```c
static void block_dealloc(io_block_t *ib, block_parts parts) {
    if (parts & BLOCK_IN) {
        free(ib->input);
        ib->input = NULL;
    }
    if (parts & BLOCK_OUT) { // <-- Uses BLOCK_OUT
        free(ib->output);
        ib->output = NULL;
    }
}
```