### PR TITLE
Bug fix for segfault

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -388,12 +388,12 @@ void queue_free(queue_t *q) {
 }
 
 void queue_push(queue_t *q, int type, void *data) {
-    pthread_mutex_lock(&q->mutex);
-    
     queue_item_t *i = malloc(sizeof(queue_item_t));
     i->type = type;
     i->data = data;
     i->next = NULL;
+    
+    pthread_mutex_lock(&q->mutex);
     
     if (q->last) {
         q->last->next = i;
@@ -415,12 +415,12 @@ int queue_pop(queue_t *q, void **datap) {
     q->first = i->next;
     if (!q->first)
         q->last = NULL;
+    pthread_mutex_unlock(&q->mutex);
     
     *datap = i->data;
     int type = i->type;
     free(i);
     
-    pthread_mutex_unlock(&q->mutex);
     return type;
 }
 

--- a/src/read.c
+++ b/src/read.c
@@ -536,7 +536,7 @@ static void read_thread(void) {
                 debug("read: skip %llu", iter.block.number_in_file);
                 continue;
             }
-            for ( ; w && w->end < uend; w = w->next) ;
+            for ( ; w && w->end <= uend; w = w->next) ;
         }
         debug("read: want %llu", iter.block.number_in_file);
         


### PR DESCRIPTION
In read_thread(), in the "Do we need this block?" block, it failed
to advance to the next wanted_t when w->end is exactly equal to uend.

In the particular case I looked at, this resulted in read_thread()
erroneously putting two blocks into the queue (pipeline_split(),
read.c:570) instead of one.

This resulted in a subsequent crash in tar_read() at read.c:660,
where gArWanted was null (when clearly the code does not expect it
to be null at that point).

My use case:

I have several hundred large .tar.xz files (created by pixz). Each
archive contains over 200k files. I frequently need to extract a lot
of files from each archive, but not all files, only a specific subset.
So I am making heavy use of the -x option to pixz.