### PR TITLE
msys2 support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -69,7 +69,7 @@ AC_FUNC_MALLOC
 AC_FUNC_REALLOC
 AC_FUNC_STRTOD
 AC_CHECK_FUNCS([memchr memmove memset strerror strtol sched_getaffinity sysconf
-  GetSystemInfo])
+  GetSystemInfo _setmode])
 AC_CHECK_HEADER([sys/endian.h],
                [
                  AC_CHECK_DECLS([htole64, le64toh], [], [], [

--- a/configure.ac
+++ b/configure.ac
@@ -69,7 +69,7 @@ AC_FUNC_MALLOC
 AC_FUNC_REALLOC
 AC_FUNC_STRTOD
 AC_CHECK_FUNCS([memchr memmove memset strerror strtol sched_getaffinity sysconf
-  GetSystemInfo _setmode])
+  GetSystemInfo _setmode _get_osfhandle])
 AC_CHECK_HEADER([sys/endian.h],
                [
                  AC_CHECK_DECLS([htole64, le64toh], [], [], [

--- a/configure.ac
+++ b/configure.ac
@@ -68,7 +68,8 @@ AC_SYS_LARGEFILE
 AC_FUNC_MALLOC
 AC_FUNC_REALLOC
 AC_FUNC_STRTOD
-AC_CHECK_FUNCS([memchr memmove memset strerror strtol sched_getaffinity])
+AC_CHECK_FUNCS([memchr memmove memset strerror strtol sched_getaffinity sysconf
+  GetSystemInfo])
 AC_CHECK_HEADER([sys/endian.h],
                [
                  AC_CHECK_DECLS([htole64, le64toh], [], [], [

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -1,28 +1,35 @@
 #define _GNU_SOURCE
 
-#include <unistd.h>
-
 #include "config.h"
 
 #ifdef HAVE_SCHED_GETAFFINITY
-
 #include <sched.h>
-#include <stdio.h>
+#endif
+
+#ifdef HAVE_SYSCONF
+#include <unistd.h>
+#endif
+
+#ifdef HAVE_GETSYSTEMINFO
+#include <sysinfoapi.h>
+#endif
 
 size_t num_threads(void) {
+#ifdef HAVE_SCHED_GETAFFINITY
     cpu_set_t cpu_set;
     CPU_ZERO(&cpu_set);
-
-    if (sched_getaffinity(0, sizeof cpu_set, &cpu_set) == -1)
-        return sysconf(_SC_NPROCESSORS_ONLN);
-    else
+    if (sched_getaffinity(0, sizeof cpu_set, &cpu_set) == 0)
         return CPU_COUNT(&cpu_set);
-}
-
-#else
-
-size_t num_threads(void) {
-    return sysconf(_SC_NPROCESSORS_ONLN);
-}
-
 #endif
+
+#ifdef HAVE_SYSCONF
+    return sysconf(_SC_NPROCESSORS_ONLN);
+#elif HAVE_GETSYSTEMINFO
+    SYSTEM_INFO sysinfo;
+    GetSystemInfo(&sysinfo);
+    return sysinfo.dwNumberOfProcessors;
+#else
+#warning "No processor-detection enabled! Assuming 2 CPUs"
+    return 2;
+#endif
+}

--- a/src/pixz.c
+++ b/src/pixz.c
@@ -172,7 +172,7 @@ int main(int argc, char **argv) {
 
     switch (op) {
         case OP_WRITE:
-			if (isatty(fileno(gOutFile)) == 1)
+			if (isatty(fileno(gOutFile)))
 				usage("Refusing to output to a TTY");
 			if (extreme)
 				level |= LZMA_PRESET_EXTREME;

--- a/src/pixz.c
+++ b/src/pixz.c
@@ -164,6 +164,12 @@ int main(int argc, char **argv) {
       }
     }
 
+#ifdef HAVE__SETMODE
+    // Set files to binary encoding
+    _setmode(_fileno(gInFile), O_BINARY);
+    _setmode(_fileno(gOutFile), O_BINARY);
+#endif
+
     switch (op) {
         case OP_WRITE:
 			if (isatty(fileno(gOutFile)) == 1)


### PR DESCRIPTION
* Add CPU detection with Win API
* Make sure files are open in binary mode, so we don't have newlines auto-translated
* Windows lies about whether seek works on pipes, so use Win API to ensure we only seek on regular files

Built with msys2/UCRT64, with UCRT64 packages (gcc, libarchive, etc). Passes all tests except the file permissions one, since permissions on msys2 are a lie.